### PR TITLE
[Modify] API 1. 문제 조회 시 중복 순회 부분 한 번만 순회하도록 개선

### DIFF
--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/ProblemService.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/ProblemService.kt
@@ -2,6 +2,7 @@ package org.freewheelin.homeschoolmaterials.domain.problem
 
 import org.freewheelin.homeschoolmaterials.domain.problem.dto.FindProblemParam
 import org.freewheelin.homeschoolmaterials.domain.problem.dto.ProblemDto
+import org.freewheelin.homeschoolmaterials.infrastructure.problem.entity.Problem
 import org.springframework.stereotype.Service
 
 @Service
@@ -13,17 +14,17 @@ class ProblemService(
         val realProblemCount = Math.min(param.totalCount, problems.size)
         val problemLevelCountMap = param.problemLevel.allocateProblemCount(realProblemCount)    // 난이도 별 문제 개수가 담긴 Map
 
-        val lowLevelProblems = problems.filter {
-            ProblemLevel.LOW.levels.contains(it.level)
-        }.take(problemLevelCountMap[ProblemLevel.LOW]!!)
+        val lowLevelProblems = mutableListOf<Problem>()
+        val mediumProblems = mutableListOf<Problem>()
+        val highProblems = mutableListOf<Problem>()
 
-        val mediumProblems = problems.filter {
-            ProblemLevel.MEDIUM.levels.contains(it.level)
-        }.take(problemLevelCountMap[ProblemLevel.MEDIUM]!!)
-
-        val highProblems = problems.filter {
-            ProblemLevel.HIGH.levels.contains(it.level)
-        }.take(problemLevelCountMap[ProblemLevel.HIGH]!!)
+        problems.forEach {
+            when {
+                ProblemLevel.LOW.levels.contains(it.level) && lowLevelProblems.size < problemLevelCountMap[ProblemLevel.LOW]!! -> lowLevelProblems.add(it)
+                ProblemLevel.MEDIUM.levels.contains(it.level) && mediumProblems.size < problemLevelCountMap[ProblemLevel.MEDIUM]!! -> mediumProblems.add(it)
+                ProblemLevel.HIGH.levels.contains(it.level) && highProblems.size < problemLevelCountMap[ProblemLevel.HIGH]!! -> highProblems.add(it)
+            }
+        }
 
         val resultProblems = lowLevelProblems + mediumProblems + highProblems
         return ProblemDto.listFrom(resultProblems)


### PR DESCRIPTION
### 작업 사항
* **이전 로직의 문제점**
    * 선택한 난이도에 따라 난이도 별 문제 수 비율에 맞게 분배하는 과정에서 중복되는 컬렉션 순회가 발생
    * `problems.filter {}`
* **개선 사항**
    * 한 번만 순회를 하도록 하고 난이도 별 문제 수 비율 분배는 `when` 문법을 사용해 해결
    * `when`을 사용해 순회한 문제 요소에 대해 난이도와 현재 분배된 난이도 별 문제 수가 분배할 문제 수를 넘기지 않는지 확인하고, 조건에 충족하면 선택

```
val lowLevelProblems = mutableListOf<Problem>()
val mediumProblems = mutableListOf<Problem>()
val highProblems = mutableListOf<Problem>()

problems.forEach {
    when {
        ProblemLevel.LOW.levels.contains(it.level) && lowLevelProblems.size < problemLevelCountMap[ProblemLevel.LOW]!! -> lowLevelProblems.add(it)
        ProblemLevel.MEDIUM.levels.contains(it.level) && mediumProblems.size < problemLevelCountMap[ProblemLevel.MEDIUM]!! -> mediumProblems.add(it)
        ProblemLevel.HIGH.levels.contains(it.level) && highProblems.size < problemLevelCountMap[ProblemLevel.HIGH]!! -> highProblems.add(it)
    }
}
```

### Issue
- related issue: #1 