### PR TITLE
[Feature] API 3. 학생에게 학습지 출제 기능 추가

### DIFF
--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/api/homeschool/HomeSchoolApi.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/api/homeschool/HomeSchoolApi.kt
@@ -9,12 +9,15 @@ import org.freewheelin.homeschoolmaterials.api.homeschool.response.AnalyzeHomeSc
 import org.freewheelin.homeschoolmaterials.api.homeschool.response.PresentHomeSchoolResponse
 import org.freewheelin.homeschoolmaterials.domain.homeschool.HomeSchoolService
 import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.CreateHomeSchoolDto
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.PresentHomeSchoolDto
+import org.freewheelin.homeschoolmaterials.facade.HomeSchoolFacade
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/api/v1/home-schools")
 @RestController
 class HomeSchoolApi(
+	private val homeSchoolFacade: HomeSchoolFacade,
 	private val homeSchoolService: HomeSchoolService
 ) {
 	/**
@@ -38,7 +41,13 @@ class HomeSchoolApi(
 	fun presentHomeSchool(
 		@RequestBody request: PresentHomeSchoolRequest
 	): ResponseEntity<PresentHomeSchoolResponse> {
-		return ResponseEntity.ok(PresentHomeSchoolResponse(1, 12345L))
+		return ResponseEntity.ok(
+			PresentHomeSchoolResponse.from(
+				homeSchoolFacade.presentHomeSchool(
+					PresentHomeSchoolDto.from(request)
+				)
+			)
+		)
 	}
 
 	/**

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/api/homeschool/request/PresentHomeSchoolRequest.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/api/homeschool/request/PresentHomeSchoolRequest.kt
@@ -2,6 +2,6 @@ package org.freewheelin.homeschoolmaterials.api.homeschool.request
 
 data class PresentHomeSchoolRequest(
 	val homeSchoolId: Long,
-	val studentId: Long,
+	val studentIds: List<Long>,
 ) {
 }

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/api/homeschool/response/PresentHomeSchoolResponse.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/api/homeschool/response/PresentHomeSchoolResponse.kt
@@ -4,13 +4,13 @@ import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.PresentHomeScho
 
 data class PresentHomeSchoolResponse(
 	val homeSchoolId: Long,
-	val studentId: Long,
+	val studentIds: List<Long>,
 ) {
 	companion object {
 		fun from(dto: PresentHomeSchoolDto): PresentHomeSchoolResponse {
 			return PresentHomeSchoolResponse(
 				dto.homeSchoolId,
-				dto.studentId
+				dto.studentIds
 			)
 		}
 	}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/api/homeschool/response/PresentHomeSchoolResponse.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/api/homeschool/response/PresentHomeSchoolResponse.kt
@@ -1,7 +1,17 @@
 package org.freewheelin.homeschoolmaterials.api.homeschool.response
 
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.PresentHomeSchoolDto
+
 data class PresentHomeSchoolResponse(
 	val homeSchoolId: Long,
 	val studentId: Long,
 ) {
+	companion object {
+		fun from(dto: PresentHomeSchoolDto): PresentHomeSchoolResponse {
+			return PresentHomeSchoolResponse(
+				dto.homeSchoolId,
+				dto.studentId
+			)
+		}
+	}
 }

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/GivenHomeSchoolRepository.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/GivenHomeSchoolRepository.kt
@@ -1,0 +1,14 @@
+package org.freewheelin.homeschoolmaterials.domain.homeschool
+
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.GivenHomeSchoolDto
+import org.freewheelin.homeschoolmaterials.infrastructure.homeschool.entity.GivenHomeSchool
+
+interface GivenHomeSchoolRepository {
+    fun getById(id: Long): GivenHomeSchool
+
+    fun save(givenHomeSchoolDto: GivenHomeSchoolDto): GivenHomeSchool
+
+    fun saveAll(givenHomeSchoolDtos: List<GivenHomeSchoolDto>): List<GivenHomeSchool>
+
+    fun deleteAll()
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolService.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolService.kt
@@ -1,7 +1,9 @@
 package org.freewheelin.homeschoolmaterials.domain.homeschool
 
 import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.CreateHomeSchoolDto
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.GivenHomeSchoolDto
 import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.HomeSchoolDto
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.PresentHomeSchoolDto
 import org.freewheelin.homeschoolmaterials.domain.problem.HomeSchoolProblemRepository
 import org.freewheelin.homeschoolmaterials.domain.problem.dto.HomeSchoolProblemDto
 import org.springframework.stereotype.Service
@@ -10,7 +12,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class HomeSchoolService(
     private val homeSchoolRepository: HomeSchoolRepository,
-    private val homeSchoolProblemRepository: HomeSchoolProblemRepository
+    private val homeSchoolProblemRepository: HomeSchoolProblemRepository,
+    private val givenHomeSchoolRepository: GivenHomeSchoolRepository
 ) {
     @Transactional
     fun createHomeSchool(createDto: CreateHomeSchoolDto): Long {
@@ -25,5 +28,11 @@ class HomeSchoolService(
         homeSchoolProblemRepository.saveAll(homeSchoolProblemDtos)
 
         return homeSchoolId
+    }
+
+    fun createGivenHomeSchoolByStudent(presentDto: PresentHomeSchoolDto): GivenHomeSchoolDto {
+        val givenDto = GivenHomeSchoolDto.of(presentDto.homeSchoolId, presentDto.studentId)
+
+        return GivenHomeSchoolDto.from(givenHomeSchoolRepository.save(givenDto))
     }
 }

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolService.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolService.kt
@@ -30,9 +30,11 @@ class HomeSchoolService(
         return homeSchoolId
     }
 
-    fun createGivenHomeSchoolByStudent(presentDto: PresentHomeSchoolDto): GivenHomeSchoolDto {
-        val givenDto = GivenHomeSchoolDto.of(presentDto.homeSchoolId, presentDto.studentId)
+    fun createGivenHomeSchoolByStudent(presentDto: PresentHomeSchoolDto): List<GivenHomeSchoolDto> {
+        val givenHomeSchoolDtos = presentDto.studentIds.map {
+            GivenHomeSchoolDto.of(presentDto.homeSchoolId, it)
+        }
 
-        return GivenHomeSchoolDto.from(givenHomeSchoolRepository.save(givenDto))
+        return GivenHomeSchoolDto.listFrom(givenHomeSchoolRepository.saveAll(givenHomeSchoolDtos))
     }
 }

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/GivenHomeSchoolDto.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/GivenHomeSchoolDto.kt
@@ -1,0 +1,34 @@
+package org.freewheelin.homeschoolmaterials.domain.homeschool.dto
+
+import org.freewheelin.homeschoolmaterials.infrastructure.homeschool.entity.GivenHomeSchool
+
+data class GivenHomeSchoolDto(
+    val id: Long,
+    val homeSchoolId: Long,
+    val studentId: Long,
+    val isDone: Boolean
+) {
+    companion object {
+        fun from(givenHomeSchool: GivenHomeSchool): GivenHomeSchoolDto {
+            return GivenHomeSchoolDto(
+                givenHomeSchool.id,
+                givenHomeSchool.homeSchoolId,
+                givenHomeSchool.studentId,
+                givenHomeSchool.isDone
+            )
+        }
+
+        fun listFrom(givenHomeSchools: List<GivenHomeSchool>): List<GivenHomeSchoolDto> {
+            return givenHomeSchools.map { from(it) }
+        }
+
+        fun of(homeSchoolId: Long, studentId: Long): GivenHomeSchoolDto {
+            return GivenHomeSchoolDto(
+                0,
+                homeSchoolId,
+                studentId,
+                false
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/PresentHomeSchoolDto.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/PresentHomeSchoolDto.kt
@@ -4,13 +4,13 @@ import org.freewheelin.homeschoolmaterials.api.homeschool.request.PresentHomeSch
 
 data class PresentHomeSchoolDto(
     val homeSchoolId: Long,
-    val studentId: Long
+    val studentIds: List<Long>
 ) {
     companion object {
         fun from(request: PresentHomeSchoolRequest): PresentHomeSchoolDto {
             return PresentHomeSchoolDto(
                 request.homeSchoolId,
-                request.studentId
+                request.studentIds
             )
         }
     }

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/PresentHomeSchoolDto.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/PresentHomeSchoolDto.kt
@@ -1,0 +1,7 @@
+package org.freewheelin.homeschoolmaterials.domain.homeschool.dto
+
+data class PresentHomeSchoolDto(
+    val homeSchoolId: Long,
+    val studentId: Long
+) {
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/PresentHomeSchoolDto.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/PresentHomeSchoolDto.kt
@@ -1,7 +1,17 @@
 package org.freewheelin.homeschoolmaterials.domain.homeschool.dto
 
+import org.freewheelin.homeschoolmaterials.api.homeschool.request.PresentHomeSchoolRequest
+
 data class PresentHomeSchoolDto(
     val homeSchoolId: Long,
     val studentId: Long
 ) {
+    companion object {
+        fun from(request: PresentHomeSchoolRequest): PresentHomeSchoolDto {
+            return PresentHomeSchoolDto(
+                request.homeSchoolId,
+                request.studentId
+            )
+        }
+    }
 }

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/ProblemService.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/ProblemService.kt
@@ -1,14 +1,17 @@
 package org.freewheelin.homeschoolmaterials.domain.problem
 
+import org.freewheelin.homeschoolmaterials.domain.problem.dto.CreateSubmittedProblemDto
 import org.freewheelin.homeschoolmaterials.domain.problem.dto.FindProblemParam
 import org.freewheelin.homeschoolmaterials.domain.problem.dto.ProblemDto
+import org.freewheelin.homeschoolmaterials.domain.problem.dto.SubmittedProblemDto
 import org.freewheelin.homeschoolmaterials.infrastructure.problem.entity.Problem
 import org.springframework.stereotype.Service
 
 @Service
 class ProblemService(
     private val problemRepository: ProblemRepository,
-    private val homeSchoolProblemRepository: HomeSchoolProblemRepository
+    private val homeSchoolProblemRepository: HomeSchoolProblemRepository,
+    private val submittedProblemRepository: SubmittedProblemRepository
 ) {
     fun getProblems(param: FindProblemParam): List<ProblemDto> {
         val problems = problemRepository.getAllByUnitCodesAndProblemType(param.unitCodes, param.problemType)
@@ -39,5 +42,15 @@ class ProblemService(
         val problems = problemRepository.getAllByIds(problemIds)
 
         return ProblemDto.listFrom(problems)
+    }
+
+    fun createSubmittedProblems(createSubmittedDto: CreateSubmittedProblemDto) {
+        val problemIds = homeSchoolProblemRepository.getAllByHomeSchoolId(createSubmittedDto.homeSchoolId).map {
+            it.problemId
+        }
+
+        problemIds.forEach {
+            submittedProblemRepository.save(SubmittedProblemDto.of(createSubmittedDto.givenHomeSchoolId, it))
+        }
     }
 }

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/SubmittedProblemRepository.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/SubmittedProblemRepository.kt
@@ -1,0 +1,14 @@
+package org.freewheelin.homeschoolmaterials.domain.problem
+
+import org.freewheelin.homeschoolmaterials.domain.problem.dto.SubmittedProblemDto
+import org.freewheelin.homeschoolmaterials.infrastructure.problem.entity.SubmittedProblem
+
+interface SubmittedProblemRepository {
+    fun getAllByGivenHomeSchoolId(givenHomeSchoolId: Long): List<SubmittedProblem>
+
+    fun save(submittedProblemDto: SubmittedProblemDto): SubmittedProblem
+
+    fun saveAll(submittedProblemDtos: List<SubmittedProblemDto>): List<SubmittedProblem>
+
+    fun deleteAll()
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/dto/CreateSubmittedProblemDto.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/dto/CreateSubmittedProblemDto.kt
@@ -1,0 +1,12 @@
+package org.freewheelin.homeschoolmaterials.domain.problem.dto
+
+data class CreateSubmittedProblemDto(
+    val homeSchoolId: Long,
+    val givenHomeSchoolId: Long
+) {
+    companion object {
+        fun of(homeSchoolId: Long, givenHomeSchoolId: Long): CreateSubmittedProblemDto {
+            return CreateSubmittedProblemDto(homeSchoolId, givenHomeSchoolId)
+        }
+    }
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/dto/SubmittedProblemDto.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/dto/SubmittedProblemDto.kt
@@ -1,0 +1,37 @@
+package org.freewheelin.homeschoolmaterials.domain.problem.dto
+
+import org.freewheelin.homeschoolmaterials.infrastructure.problem.entity.SubmittedProblem
+
+data class SubmittedProblemDto(
+    val id: Long,
+    val givenHomeSchoolId: Long,
+    val problemId: Long,
+    val submitAnswer: String,
+    val isAnswered: Boolean
+) {
+    companion object {
+        fun from(submittedProlem: SubmittedProblem): SubmittedProblemDto {
+            return SubmittedProblemDto(
+                submittedProlem.id,
+                submittedProlem.givenHomeSchoolId,
+                submittedProlem.problemId,
+                submittedProlem.submitAnswer,
+                submittedProlem.isAnswered
+            )
+        }
+
+        fun listFrom(submittedProblems: List<SubmittedProblem>): List<SubmittedProblemDto> {
+            return submittedProblems.map { from(it) }
+        }
+
+        fun of(givenHomeSchoolId: Long, problemId: Long): SubmittedProblemDto {
+            return SubmittedProblemDto(
+                0,
+                givenHomeSchoolId,
+                problemId,
+                "",
+                false
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/facade/HomeSchoolFacade.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/facade/HomeSchoolFacade.kt
@@ -1,0 +1,24 @@
+package org.freewheelin.homeschoolmaterials.facade
+
+import org.freewheelin.homeschoolmaterials.domain.homeschool.HomeSchoolService
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.PresentHomeSchoolDto
+import org.freewheelin.homeschoolmaterials.domain.problem.ProblemService
+import org.freewheelin.homeschoolmaterials.domain.problem.dto.CreateSubmittedProblemDto
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class HomeSchoolFacade(
+    private val homeSchoolService: HomeSchoolService,
+    private val problemService: ProblemService
+) {
+    @Transactional
+    fun presentHomeSchool(presentHomeSchoolDto: PresentHomeSchoolDto): PresentHomeSchoolDto {
+        val givenHomeSchoolDto = homeSchoolService.createGivenHomeSchoolByStudent(presentHomeSchoolDto)
+        problemService.createSubmittedProblems(
+            CreateSubmittedProblemDto.of(givenHomeSchoolDto.homeSchoolId, givenHomeSchoolDto.id)
+        )
+
+        return presentHomeSchoolDto
+    }
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/facade/HomeSchoolFacade.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/facade/HomeSchoolFacade.kt
@@ -14,10 +14,12 @@ class HomeSchoolFacade(
 ) {
     @Transactional
     fun presentHomeSchool(presentHomeSchoolDto: PresentHomeSchoolDto): PresentHomeSchoolDto {
-        val givenHomeSchoolDto = homeSchoolService.createGivenHomeSchoolByStudent(presentHomeSchoolDto)
-        problemService.createSubmittedProblems(
-            CreateSubmittedProblemDto.of(givenHomeSchoolDto.homeSchoolId, givenHomeSchoolDto.id)
-        )
+        val givenHomeSchoolDtos = homeSchoolService.createGivenHomeSchoolByStudent(presentHomeSchoolDto)
+        givenHomeSchoolDtos.forEach {
+            problemService.createSubmittedProblems(
+                CreateSubmittedProblemDto.of(it.homeSchoolId, it.id)
+            )
+        }
 
         return presentHomeSchoolDto
     }

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/homeschool/GivenHomeSchoolJpaRepository.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/homeschool/GivenHomeSchoolJpaRepository.kt
@@ -1,0 +1,7 @@
+package org.freewheelin.homeschoolmaterials.infrastructure.homeschool
+
+import org.freewheelin.homeschoolmaterials.infrastructure.homeschool.entity.GivenHomeSchool
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GivenHomeSchoolJpaRepository : JpaRepository<GivenHomeSchool, Long> {
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/homeschool/GivenHomeSchoolRepositoryImpl.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/homeschool/GivenHomeSchoolRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package org.freewheelin.homeschoolmaterials.infrastructure.homeschool
+
+import org.freewheelin.homeschoolmaterials.domain.homeschool.GivenHomeSchoolRepository
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.GivenHomeSchoolDto
+import org.freewheelin.homeschoolmaterials.infrastructure.homeschool.entity.GivenHomeSchool
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import org.webjars.NotFoundException
+
+@Repository
+class GivenHomeSchoolRepositoryImpl(
+    private val jpaRepository: GivenHomeSchoolJpaRepository
+) : GivenHomeSchoolRepository {
+    override fun getById(id: Long): GivenHomeSchool {
+        return jpaRepository.findByIdOrNull(id)
+            ?: throw NotFoundException("ID: ${id}에 해당하는 GivenHomeSchool을 찾을 수 없음")
+    }
+
+    override fun save(givenHomeSchoolDto: GivenHomeSchoolDto): GivenHomeSchool {
+        return jpaRepository.save(GivenHomeSchool.from(givenHomeSchoolDto))
+    }
+
+    override fun saveAll(givenHomeSchoolDtos: List<GivenHomeSchoolDto>): List<GivenHomeSchool> {
+        return jpaRepository.saveAll(GivenHomeSchool.listFrom(givenHomeSchoolDtos))
+    }
+
+    override fun deleteAll() {
+        jpaRepository.deleteAll()
+    }
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/homeschool/entity/GivenHomeSchool.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/homeschool/entity/GivenHomeSchool.kt
@@ -1,0 +1,36 @@
+package org.freewheelin.homeschoolmaterials.infrastructure.homeschool.entity
+
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.GivenHomeSchoolDto
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+
+@Entity
+class GivenHomeSchool(
+    val homeSchoolId: Long,
+    val studentId: Long
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    var id: Long = 0
+
+    var isDone = false
+
+    constructor(homeSchoolId: Long, studentId: Long, isDone: Boolean) : this(homeSchoolId, homeSchoolId) {
+        this.isDone = isDone
+    }
+
+    companion object {
+        fun from(dto: GivenHomeSchoolDto): GivenHomeSchool {
+            return GivenHomeSchool(
+                dto.homeSchoolId,
+                dto.studentId
+            )
+        }
+
+        fun listFrom(dtos: List<GivenHomeSchoolDto>): List<GivenHomeSchool> {
+            return dtos.map { from(it) }
+        }
+    }
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/problem/SubmittedProblemJpaRepository.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/problem/SubmittedProblemJpaRepository.kt
@@ -1,0 +1,8 @@
+package org.freewheelin.homeschoolmaterials.infrastructure.problem
+
+import org.freewheelin.homeschoolmaterials.infrastructure.problem.entity.SubmittedProblem
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SubmittedProblemJpaRepository : JpaRepository<SubmittedProblem, Long> {
+    fun findAllByGivenHomeSchoolId(givenHomeSchoolId: Long): List<SubmittedProblem>
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/problem/SubmittedProblemRepositoryImpl.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/problem/SubmittedProblemRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package org.freewheelin.homeschoolmaterials.infrastructure.problem
+
+import org.freewheelin.homeschoolmaterials.domain.problem.SubmittedProblemRepository
+import org.freewheelin.homeschoolmaterials.domain.problem.dto.SubmittedProblemDto
+import org.freewheelin.homeschoolmaterials.infrastructure.problem.entity.SubmittedProblem
+import org.springframework.stereotype.Repository
+
+@Repository
+class SubmittedProblemRepositoryImpl(
+    private val jpaRepository: SubmittedProblemJpaRepository
+) : SubmittedProblemRepository {
+    override fun getAllByGivenHomeSchoolId(givenHomeSchoolId: Long): List<SubmittedProblem> {
+        return jpaRepository.findAllByGivenHomeSchoolId(givenHomeSchoolId)
+    }
+
+    override fun save(submittedProblemDto: SubmittedProblemDto): SubmittedProblem {
+        return jpaRepository.save(SubmittedProblem.from(submittedProblemDto))
+    }
+
+    override fun saveAll(submittedProblemDtos: List<SubmittedProblemDto>): List<SubmittedProblem> {
+        return jpaRepository.saveAll(SubmittedProblem.listFrom(submittedProblemDtos))
+    }
+
+    override fun deleteAll() {
+        jpaRepository.deleteAll()
+    }
+}

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/problem/entity/SubmittedProblem.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/infrastructure/problem/entity/SubmittedProblem.kt
@@ -1,0 +1,34 @@
+package org.freewheelin.homeschoolmaterials.infrastructure.problem.entity
+
+import org.freewheelin.homeschoolmaterials.domain.problem.dto.SubmittedProblemDto
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+
+@Entity
+class SubmittedProblem(
+    val givenHomeSchoolId: Long,
+    val problemId: Long
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    var id: Long = 0
+
+    var submitAnswer: String = ""
+
+    var isAnswered: Boolean = false
+
+    companion object {
+        fun from(dto: SubmittedProblemDto): SubmittedProblem {
+            return SubmittedProblem(
+                dto.givenHomeSchoolId,
+                dto.problemId
+            )
+        }
+
+        fun listFrom(dtos: List<SubmittedProblemDto>): List<SubmittedProblem> {
+            return dtos.map { from(it) }
+        }
+    }
+}

--- a/src/main/resources/http/homeSchoolApiRequest.http
+++ b/src/main/resources/http/homeSchoolApiRequest.http
@@ -14,7 +14,7 @@ Content-Type: application/json
 
 {
   "homeSchoolId": 1,
-  "studentId": 12345
+  "studentId": [12345, 12346, 12347]
 }
 
 ### 학습지 학습 통계 분석 API

--- a/src/test/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolServiceIntegrationTest.kt
@@ -46,13 +46,19 @@ class HomeSchoolServiceIntegrationTest {
     @Test
     @DisplayName("학습지 출제 테스트: homeSchoolId가 1, studentId가 123인 경우 학생에게 학습지 출제 데이터 생성하기")
     fun createGivenHomeSchoolTest() {
-        val presentHomeSchoolDto = PresentHomeSchoolDto(1L, 123L)
+        val presentHomeSchoolDto = PresentHomeSchoolDto(
+            1L,
+            listOf(123L, 456L)
+        )
 
-        val givenHomeSchoolId = sut.createGivenHomeSchoolByStudent(presentHomeSchoolDto).id
+        val givenHomeSchoolIds = sut.createGivenHomeSchoolByStudent(presentHomeSchoolDto).map { it.id }
 
-        val actual = givenHomeSchoolRepository.getById(givenHomeSchoolId)
+        val actual = givenHomeSchoolIds.map {
+            givenHomeSchoolRepository.getById(it)
+        }
 
-        assertThat(actual.homeSchoolId).isEqualTo(1L)
-        assertThat(actual.studentId).isEqualTo(123L)
+        assertThat(actual.size).isEqualTo(2)
+        assertThat(actual[0].studentId).isEqualTo(123L)
+        assertThat(actual[1].studentId).isEqualTo(456L)
     }
 }

--- a/src/test/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolServiceIntegrationTest.kt
@@ -2,6 +2,7 @@ package org.freewheelin.homeschoolmaterials.domain.homeschool
 
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.CreateHomeSchoolDto
+import org.freewheelin.homeschoolmaterials.domain.homeschool.dto.PresentHomeSchoolDto
 import org.freewheelin.homeschoolmaterials.domain.problem.HomeSchoolProblemRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -14,11 +15,13 @@ class HomeSchoolServiceIntegrationTest {
     @Autowired lateinit var sut: HomeSchoolService
     @Autowired lateinit var homeSchoolRepository: HomeSchoolRepository
     @Autowired lateinit var homeSchoolProblemRepository: HomeSchoolProblemRepository
+    @Autowired lateinit var givenHomeSchoolRepository: GivenHomeSchoolRepository
 
     @BeforeEach
     fun clearDB() {
         homeSchoolRepository.deleteAll()
         homeSchoolProblemRepository.deleteAll()
+        givenHomeSchoolRepository.deleteAll()
     }
 
     @Test
@@ -38,5 +41,18 @@ class HomeSchoolServiceIntegrationTest {
         assertThat(homeSchool.name).isEqualTo("2024 모의고사")
         assertThat(homeSchool.teacherId).isEqualTo(123L)
         assertThat(homeSchoolProblems.size).isEqualTo(5)
+    }
+
+    @Test
+    @DisplayName("학습지 출제 테스트: homeSchoolId가 1, studentId가 123인 경우 학생에게 학습지 출제 데이터 생성하기")
+    fun createGivenHomeSchoolTest() {
+        val presentHomeSchoolDto = PresentHomeSchoolDto(1L, 123L)
+
+        val givenHomeSchoolId = sut.createGivenHomeSchoolByStudent(presentHomeSchoolDto).id
+
+        val actual = givenHomeSchoolRepository.getById(givenHomeSchoolId)
+
+        assertThat(actual.homeSchoolId).isEqualTo(1L)
+        assertThat(actual.studentId).isEqualTo(123L)
     }
 }

--- a/src/test/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/ProblemServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/ProblemServiceIntegrationTest.kt
@@ -1,6 +1,7 @@
 package org.freewheelin.homeschoolmaterials.domain.problem
 
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.freewheelin.homeschoolmaterials.domain.problem.dto.CreateSubmittedProblemDto
 import org.freewheelin.homeschoolmaterials.domain.problem.dto.FindProblemParam
 import org.freewheelin.homeschoolmaterials.domain.problem.dto.HomeSchoolProblemDto
 import org.freewheelin.homeschoolmaterials.domain.problem.dto.ProblemDto
@@ -17,11 +18,13 @@ class ProblemServiceIntegrationTest {
     @Autowired lateinit var sut: ProblemService
     @Autowired lateinit var problemRepository: ProblemRepository
     @Autowired lateinit var homeSchoolProblemRepository: HomeSchoolProblemRepository
+    @Autowired lateinit var submittedProblemRepository: SubmittedProblemRepository
 
     @BeforeEach
     fun clearDB() {
         problemRepository.deleteAll()
         homeSchoolProblemRepository.deleteAll()
+        submittedProblemRepository.deleteAll()
     }
 
     private fun makeProblems(unitCode: UnitCode, problemType: ProblemType): List<Problem> {
@@ -93,6 +96,20 @@ class ProblemServiceIntegrationTest {
         assertThat(actual.map { it.id }.contains(1)).isTrue()
         assertThat(actual.map { it.id }.contains(2)).isTrue()
         assertThat(actual.map { it.id }.contains(3)).isTrue()
+    }
+
+    @Test
+    @DisplayName("학생에게 출제된 학습지의 문제를 저장하는 기능 테스트")
+    fun createSubmittedProblemTest() {
+        problemRepository.saveAll(ProblemDto.listFrom(makeProblems(UnitCode.UC_1580, ProblemType.SELECTION)))
+        homeSchoolProblemRepository.saveAll(HomeSchoolProblemDto.listFrom(makeHomeSchoolProblem(1L)))
+
+        sut.createSubmittedProblems(CreateSubmittedProblemDto.of(1L, 2L))
+
+        val actual = submittedProblemRepository.getAllByGivenHomeSchoolId(2L)
+
+        assertThat(actual.size).isEqualTo(3)
+        assertThat(actual.map { it.givenHomeSchoolId }.all { it == 2L }).isTrue()
     }
 
 }


### PR DESCRIPTION
### 작업 사항
* 학생에게 학습지 출제 기능 구현, 아래 출제 관련 데이터 저장 기능 구현
    * GivenHomeSchool: 학생 별 출제된 학습지 정보를 저장하는 테이블. 학습지 ID, 학생 ID, 제출 완료 유무
    * SubmittedProblem: 출제된 학습지 별 문제 정보를 저장하는 테이블. 출제된 학습지 ID, 문제 ID, 학생이 제출한 답, 정답 유무
* 학습지 출제 시 각 데이터 저장 기능 통합테스트 작성

### Issue
* related issue: #3 