### PR TITLE
[Modify] API 3. 학생에게 학습지 출제 중 반복적인 출제 문제 데이터 저장 시 saveAll() 사용

### DIFF
--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/ProblemService.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/problem/ProblemService.kt
@@ -45,12 +45,11 @@ class ProblemService(
     }
 
     fun createSubmittedProblems(createSubmittedDto: CreateSubmittedProblemDto) {
-        val problemIds = homeSchoolProblemRepository.getAllByHomeSchoolId(createSubmittedDto.homeSchoolId).map {
-            it.problemId
+        val submittedProblemDtos = homeSchoolProblemRepository.getAllByHomeSchoolId(createSubmittedDto.homeSchoolId).map {
+            val problemId = it.problemId
+            SubmittedProblemDto.of(createSubmittedDto.givenHomeSchoolId, problemId)
         }
 
-        problemIds.forEach {
-            submittedProblemRepository.save(SubmittedProblemDto.of(createSubmittedDto.givenHomeSchoolId, it))
-        }
+        submittedProblemRepository.saveAll(submittedProblemDtos)
     }
 }


### PR DESCRIPTION
### 작업 사항
* 학생에게 출제한 문제인 SubmittedProblem 데이터를 저장할 때 반복적으로 `save()`를 호출하는 방식에서 `saveAll()`을 활용하는 방식으로 수정
* INSERT가 많이 발생하는 학습지 출제 기능 특성 상 최대한의 성능 개선이 필요하여 수정 작업 진행

### Issue
* related: #3 