### PR TITLE
[Modify]: API 2. 학습지 생성 시 학습지의 최대 문제 수 검사 수행

### DIFF
--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolService.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/HomeSchoolService.kt
@@ -7,6 +7,8 @@ import org.freewheelin.homeschoolmaterials.domain.problem.dto.HomeSchoolProblemD
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
+private const val MAX_PROBLEM_LENGTH = 50
+
 @Service
 class HomeSchoolService(
     private val homeSchoolRepository: HomeSchoolRepository,
@@ -14,6 +16,8 @@ class HomeSchoolService(
 ) {
     @Transactional
     fun createHomeSchool(createDto: CreateHomeSchoolDto): Long {
+        createDto.checkMaxProblemLength(MAX_PROBLEM_LENGTH)
+
         val homeSchoolDto = HomeSchoolDto.of(createDto.teacherId, createDto.name)
 
         val homeSchoolId = homeSchoolRepository.save(homeSchoolDto).id

--- a/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/CreateHomeSchoolDto.kt
+++ b/src/main/kotlin/org/freewheelin/homeschoolmaterials/domain/homeschool/dto/CreateHomeSchoolDto.kt
@@ -7,6 +7,12 @@ data class CreateHomeSchoolDto(
     val teacherId: Long,
     val problemIds: List<Long>
 ) {
+    fun checkMaxProblemLength(maxLength: Int) {
+        if (problemIds.size > maxLength) {
+            throw IllegalArgumentException("학습지의 문제 수는 ${maxLength}개를 넘길 수 없습니다.")
+        }
+    }
+
     companion object {
         fun from(createRequest: CreateHomeSchoolRequest): CreateHomeSchoolDto {
             return CreateHomeSchoolDto(


### PR DESCRIPTION
### 작업 사항
- 학습지 생성 시 학습지에 포함할 수 있는 최대 문제 개수를 검사하도록 작업

### Issue
- related: #2 